### PR TITLE
Remove suppressImplicitAnyIndexErrors

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "es6",
     "module": "commonjs",
     "strict": true,
-    "suppressImplicitAnyIndexErrors": true,
     "noEmitOnError": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true


### PR DESCRIPTION
Using `suppressImplicitAnyIndexErrors: true` in `tsconfig.json`, paired
with no declaration file being built before publishing, causes errors in
projects that do not have this option enabled, because the compiler must
parse the original .ts files and extract types from them, and it uses
the project-wide `tsconfig.json` for this.

To remedy that, remove `suppressImplicitAnyIndexErrors` from the
TypeScript configuration and fix errors that come up.

Some of the errors couldn't be fixed by just using known types from the
TypeScript compiler, as some interfaces which are used in the library
are internal to the compiler and not exposed to consumers. In these
cases, we define the types on our own and forcibly cast the values to
those types.